### PR TITLE
Added support for int8 and int16 datatypes

### DIFF
--- a/package/int16.go
+++ b/package/int16.go
@@ -1,0 +1,10 @@
+package interconv
+
+// ParseInt16 function converts data of any type to int16
+func ParseInt16(val interface{}) (int16, error) {
+	number, err := ParseFloat64(val)
+	if err != nil {
+		return -1, err
+	}
+	return int16(number), err
+}

--- a/package/int16_test.go
+++ b/package/int16_test.go
@@ -1,0 +1,29 @@
+package interconv_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	interconv "github.com/mufti1/interconv/package"
+)
+
+func TestParseInt16(t *testing.T) {
+	t.Run("Nil", func(t *testing.T) {
+		convertedNum, _ := interconv.ParseInt16(nil)
+		if convertedNum != 1 {
+			t.Fatalf("return must be 1 instead of %v", convertedNum)
+		}
+	})
+	t.Run("Json Number", func(t *testing.T) {
+		convertedNum, _ := interconv.ParseInt16(json.Number("100"))
+		if convertedNum != 100.0 {
+			t.Fatalf("return must be 100.0 instead of %v", convertedNum)
+		}
+	})
+	t.Run("Error value", func(t *testing.T) {
+		_, err := interconv.ParseInt16("test")
+		if err == nil {
+			t.Fatalf("it should be error: %v", err)
+		}
+	})
+}

--- a/package/int8.go
+++ b/package/int8.go
@@ -1,0 +1,10 @@
+package interconv
+
+// ParseInt8 function converts data of any type to int8
+func ParseInt8(val interface{}) (int8, error) {
+	number, err := ParseFloat64(val)
+	if err != nil {
+		return -1, err
+	}
+	return int8(number), err
+}

--- a/package/int8_test.go
+++ b/package/int8_test.go
@@ -1,0 +1,29 @@
+package interconv_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	interconv "github.com/mufti1/interconv/package"
+)
+
+func TestParseInt8(t *testing.T) {
+	t.Run("Nil", func(t *testing.T) {
+		convertedNum, _ := interconv.ParseInt8(nil)
+		if convertedNum != 1 {
+			t.Fatalf("return must be 1 instead of %v", convertedNum)
+		}
+	})
+	t.Run("Json Number", func(t *testing.T) {
+		convertedNum, _ := interconv.ParseInt8(json.Number("100"))
+		if convertedNum != 100.0 {
+			t.Fatalf("return must be 100.0 instead of %v", convertedNum)
+		}
+	})
+	t.Run("Error value", func(t *testing.T) {
+		_, err := interconv.ParseInt8("test")
+		if err == nil {
+			t.Fatalf("it should be error: %v", err)
+		}
+	})
+}


### PR DESCRIPTION
This PR aims at introducing support for int8 and int16 data types in the package intercom